### PR TITLE
fixes so error doesnt show when a non marker is clicked

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -98,9 +98,11 @@ var loadMap = function(eventList) {
 
 	main_map.addEventListener('click', function() {
 		var markerWindows = document.getElementsByClassName('marker-info');
-		markerWindows[0].addEventListener('click', function(){
-			loadSingleEvent(eventList, this.id);
-		})
+		if(markerWindows.length > 0){
+			markerWindows[0].addEventListener('click', function(){
+				loadSingleEvent(eventList, this.id);
+			})
+		}
 	})
 };
 


### PR DESCRIPTION
When anywhere on the map was clicked, it tried to add an event listener to an info window that didn't exist.
