### PR TITLE
Feature/event form page css

### DIFF
--- a/client/build/public/main.css
+++ b/client/build/public/main.css
@@ -145,6 +145,16 @@ h2 {
   margin-bottom: 10px;
 }
 
+input.break #form-description {
+  word-wrap: break-word;
+  word-break: break-all;
+  height: 80px;
+}
+#form-description {
+  height: 80px;
+}
+
+
 #event-image{
   height: 190px;
   width: 500px;

--- a/client/build/public/main.css
+++ b/client/build/public/main.css
@@ -150,10 +150,6 @@ input.break #form-description {
   word-break: break-all;
   height: 80px;
 }
-#form-description {
-  height: 80px;
-}
-
 
 #event-image{
   height: 190px;


### PR DESCRIPTION
Description box made larger, and text no longer spills off page so the person can't see it.  Still doesn't wrap text though, so need a fix for this.  

I think the input needs to be changed to a textarea element rather than an input element, ref this > [](https://stackoverflow.com/questions/5286663/wrapping-text-inside-input-type-text-element-html-css).  